### PR TITLE
fix: copy http options from opts (not opts.uri)

### DIFF
--- a/index.js
+++ b/index.js
@@ -324,7 +324,9 @@ function setDefaults(defs) {
             'timeout',
             'setHost'
         ].forEach(function (key) {
-            finalOpts[key] = opts.uri[key];
+            if (key in opts) {
+                finalOpts[key] = opts[key];
+            }
         });
 
         finalOpts.method = opts.method;


### PR DESCRIPTION
Found this bug today when I needed to modify the `agent`.

I'm surprised I haven't needed this before.