### PR TITLE
fix: register otherwise silent http response error

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,6 +120,9 @@ function handleResponse(resp, opts, cb) {
         resp.body = '';
     }
     resp._bodyLength = 0;
+    resp.once('error', function (err) {
+        cb(err, resp, resp.body);
+    });
     resp.on('readable', function () {
         var chunk;
         while ((chunk = resp.read())) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
     "name": "@root/request",
-    "version": "1.8.2",
+    "version": "1.8.3",
     "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@root/request",
-    "version": "1.8.2",
+    "version": "1.8.3",
     "description": "A lightweight, zero-dependency drop-in replacement for request",
     "main": "index.js",
     "files": [


### PR DESCRIPTION
> For backward compatibility, res will only emit 'error' if there is an 'error' listener registered.

Oops!